### PR TITLE
Qt5 compatibility

### DIFF
--- a/ab90_reset.py
+++ b/ab90_reset.py
@@ -2,8 +2,31 @@
 
 # (c) 2017
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+import platform
+
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+
 import ecu
 import options
 import elm
@@ -15,19 +38,19 @@ category = _("Airbag Tools")
 need_hw = True
 ecufile = "AB90_J77_X85"
 
-class Virginizer(gui.QDialog):
+class Virginizer(widgets.QDialog):
     def __init__(self):
         super(Virginizer, self).__init__()
         self.airbag_ecu = ecu.Ecu_file(ecufile, True)
-        layout = gui.QVBoxLayout()
-        infos = gui.QLabel(_("AB90 (Clio III)/2<br>"
+        layout = widgets.QVBoxLayout()
+        infos = widgets.QLabel(_("AB90 (Clio III)/2<br>"
                            "AIRBAG VIRGINIZER<br><font color='red'>THIS PLUGIN WILL UNLOCK AIRBAG CRASH DATA<br>"
                            "GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
         infos.setAlignment(core.Qt.AlignHCenter)
-        check_button = gui.QPushButton(_("Check ACU Virgin"))
-        self.status_check = gui.QLabel(_("Waiting"))
+        check_button = widgets.QPushButton(_("Check ACU Virgin"))
+        self.status_check = widgets.QLabel(_("Waiting"))
         self.status_check.setAlignment(core.Qt.AlignHCenter)
-        self.virginize_button = gui.QPushButton(_("Virginize ACU"))
+        self.virginize_button = widgets.QPushButton(_("Virginize ACU"))
         layout.addWidget(infos)
         layout.addWidget(check_button)
         layout.addWidget(self.status_check)

--- a/clio3_eps_reset.py
+++ b/clio3_eps_reset.py
@@ -2,8 +2,31 @@
 
 # (c) 2017
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+import platform
+
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+
 import ecu
 import options
 import crcmod
@@ -27,32 +50,32 @@ def calc_crc(vin=None):
     # Convert it to big endian
     return crcle[2:4] + crcle[0:2]
 
-class Virginizer(gui.QDialog):
+class Virginizer(widgets.QDialog):
     def __init__(self):
         super(Virginizer, self).__init__()
         self.clio_eps = ecu.Ecu_file(ecufile, True)
-        layout = gui.QVBoxLayout()
-        infos = gui.QLabel(_("Modus/Clio III EPS VIRGINIZER<br><font color='red'>THIS PLUGIN WILL RESET EPS IMMO DATA<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
+        layout = widgets.QVBoxLayout()
+        infos = widgets.QLabel(_("Modus/Clio III EPS VIRGINIZER<br><font color='red'>THIS PLUGIN WILL RESET EPS IMMO DATA<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
         infos.setAlignment(core.Qt.AlignHCenter)
-        check_button = gui.QPushButton(_("BLANK STATUS & VIN READ"))
-        self.status_check = gui.QLabel(_("Waiting"))
+        check_button = widgets.QPushButton(_("BLANK STATUS & VIN READ"))
+        self.status_check = widgets.QLabel(_("Waiting"))
         self.status_check.setAlignment(core.Qt.AlignHCenter)
-        self.virginize_button = gui.QPushButton(_("Virginize EPS"))
+        self.virginize_button = widgets.QPushButton(_("Virginize EPS"))
 
         self.setLayout(layout)
         self.virginize_button.setEnabled(False)
         self.virginize_button.clicked.connect(self.reset_ecu)
         check_button.clicked.connect(self.check_virgin_status)
-        status_vin = gui.QLabel(_("VIN - READ"))
+        status_vin = widgets.QLabel(_("VIN - READ"))
         status_vin.setAlignment(core.Qt.AlignHCenter)
-        self.vin_input = gui.QLineEdit()
+        self.vin_input = widgets.QLineEdit()
         self.vin_input.setReadOnly(True)
 
-        status_vinout = gui.QLabel(_("VIN - WRITE"))
+        status_vinout = widgets.QLabel(_("VIN - WRITE"))
         status_vinout.setAlignment(core.Qt.AlignHCenter)
-        self.vin_output = gui.QLineEdit()
+        self.vin_output = widgets.QLineEdit()
 
-        write_vin_button = gui.QPushButton(_("Write VIN"))
+        write_vin_button = widgets.QPushButton(_("Write VIN"))
         write_vin_button.clicked.connect(self.write_vin)
 
         layout.addWidget(infos)
@@ -76,7 +99,10 @@ class Virginizer(gui.QDialog):
 
     def write_vin(self):
         try:
-            vin = str(self.vin_output.text().toAscii()).upper()
+            if qt5:
+                vin = str(self.vin_output.text().encode("ascii", errors='"ignore')).upper()
+            else:
+                vin = str(self.vin_output.text().toAscii()).upper()
             self.vin_output.setText(vin)
         except:
             self.status_check.setText(_("<font color='red'>VIN - INVALID</font>"))

--- a/clio4_eps_reset.py
+++ b/clio4_eps_reset.py
@@ -2,8 +2,31 @@
 
 # (c) 2017
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+import platform
+
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+
 import ecu
 import options
 import elm
@@ -16,17 +39,17 @@ need_hw = True
 ecufile = "X98ph2_X87ph2_EPS_HFP_v1.00_20150622T140219_20160726T172209"
 
 
-class Virginizer(gui.QDialog):
+class Virginizer(widgets.QDialog):
     def __init__(self):
         super(Virginizer, self).__init__()
         self.clio_eps = ecu.Ecu_file(ecufile, True)
-        layout = gui.QVBoxLayout()
-        infos = gui.QLabel(_("Clio IV EPS VIRGINIZER<br><font color='red'>THIS PLUGIN WILL RESET EPS IMMO DATA<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
+        layout = widgets.QVBoxLayout()
+        infos = widgets.QLabel(_("Clio IV EPS VIRGINIZER<br><font color='red'>THIS PLUGIN WILL RESET EPS IMMO DATA<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
         infos.setAlignment(core.Qt.AlignHCenter)
-        check_button = gui.QPushButton(_("Check EPS Virgin"))
-        self.status_check = gui.QLabel(_("Waiting"))
+        check_button = widgets.QPushButton(_("Check EPS Virgin"))
+        self.status_check = widgets.QLabel(_("Waiting"))
         self.status_check.setAlignment(core.Qt.AlignHCenter)
-        self.virginize_button = gui.QPushButton(_("Virginize EPS"))
+        self.virginize_button = widgets.QPushButton(_("Virginize EPS"))
         layout.addWidget(infos)
         layout.addWidget(check_button)
         layout.addWidget(self.status_check)

--- a/laguna2_uch_reset.py
+++ b/laguna2_uch_reset.py
@@ -3,8 +3,31 @@
 # (c) 2017
 # This is an example plugin
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+import platform
+
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+
 import ecu
 import options
 import elm
@@ -16,17 +39,17 @@ category = _("UCH Tools")
 need_hw = True
 ecufile = "UCH___M2S_X74_et_X73"
 
-class Virginizer(gui.QDialog):
+class Virginizer(widgets.QDialog):
     def __init__(self):
         super(Virginizer, self).__init__()
         self.laguna_uch = ecu.Ecu_file(ecufile, True)
-        layout = gui.QVBoxLayout()
-        infos = gui.QLabel(_("LAGUNA II UCH VIRGINIZER<br><font color='red'>THIS PLUGIN WILL ERASE YOUR UCH<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
+        layout = widgets.QVBoxLayout()
+        infos = widgets.QLabel(_("LAGUNA II UCH VIRGINIZER<br><font color='red'>THIS PLUGIN WILL ERASE YOUR UCH<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
         infos.setAlignment(core.Qt.AlignHCenter)
-        check_button = gui.QPushButton(_("Check UCH Virgin"))
-        self.status_check = gui.QLabel(_("Waiting"))
+        check_button = widgets.QPushButton(_("Check UCH Virgin"))
+        self.status_check = widgets.QLabel(_("Waiting"))
         self.status_check.setAlignment(core.Qt.AlignHCenter)
-        self.virginize_button = gui.QPushButton(_("Virginize UCH"))
+        self.virginize_button = widgets.QPushButton(_("Virginize UCH"))
         layout.addWidget(infos)
         layout.addWidget(check_button)
         layout.addWidget(self.status_check)

--- a/laguna3_uch_reset.py
+++ b/laguna3_uch_reset.py
@@ -2,8 +2,31 @@
 
 # (c) 2017
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+import platform
+
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+
 import ecu
 import options
 import elm
@@ -15,17 +38,17 @@ category = _("UCH Tools")
 need_hw = True
 ecufile = "BCM_X91_L43_S_S_SWC_v1.30_20140613T140906"
 
-class Virginizer(gui.QDialog):
+class Virginizer(widgets.QDialog):
     def __init__(self):
         super(Virginizer, self).__init__()
         self.megane_uch = ecu.Ecu_file(ecufile, True)
-        layout = gui.QVBoxLayout()
-        infos = gui.QLabel(_("LAGUNA III UCH VIRGINIZER<br><font color='red'>THIS PLUGIN WILL ERASE YOUR UCH<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
+        layout = widgets.QVBoxLayout()
+        infos = widgets.QLabel(_("LAGUNA III UCH VIRGINIZER<br><font color='red'>THIS PLUGIN WILL ERASE YOUR UCH<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
         infos.setAlignment(core.Qt.AlignHCenter)
-        check_button = gui.QPushButton(_("Check UCH Virgin"))
-        self.status_check = gui.QLabel(_("Waiting"))
+        check_button = widgets.QPushButton(_("Check UCH Virgin"))
+        self.status_check = widgets.QLabel(_("Waiting"))
         self.status_check.setAlignment(core.Qt.AlignHCenter)
-        self.virginize_button = gui.QPushButton(_("Virginize UCH"))
+        self.virginize_button = widgets.QPushButton(_("Virginize UCH"))
         layout.addWidget(infos)
         layout.addWidget(check_button)
         layout.addWidget(self.status_check)

--- a/megane2_uch_reset.py
+++ b/megane2_uch_reset.py
@@ -3,8 +3,31 @@
 # (c) 2017
 # This is an example plugin
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+import platform
+
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+    
 import ecu
 import options
 import elm
@@ -16,17 +39,17 @@ category = _("UCH Tools")
 need_hw = True
 
 
-class Virginizer(gui.QDialog):
+class Virginizer(widgets.QDialog):
     def __init__(self):
         super(Virginizer, self).__init__()
         self.megane_uch = ecu.Ecu_file("UCH_84_J84_03_60", True)
-        layout = gui.QVBoxLayout()
-        infos = gui.QLabel(_("MEGANE II UCH VIRGINIZER<br><font color='red'>THIS PLUGIN WILL ERASE YOUR UCH<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
+        layout = widgets.QVBoxLayout()
+        infos = widgets.QLabel(_("MEGANE II UCH VIRGINIZER<br><font color='red'>THIS PLUGIN WILL ERASE YOUR UCH<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
         infos.setAlignment(core.Qt.AlignHCenter)
-        check_button = gui.QPushButton(_("Check UCH Virgin"))
-        self.status_check = gui.QLabel(_("Waiting"))
+        check_button = widgets.QPushButton(_("Check UCH Virgin"))
+        self.status_check = widgets.QLabel(_("Waiting"))
         self.status_check.setAlignment(core.Qt.AlignHCenter)
-        self.virginize_button = gui.QPushButton(_("Virginize UCH"))
+        self.virginize_button = widgets.QPushButton(_("Virginize UCH"))
         layout.addWidget(infos)
         layout.addWidget(check_button)
         layout.addWidget(self.status_check)

--- a/megane3_ab_reset.py
+++ b/megane3_ab_reset.py
@@ -2,8 +2,31 @@
 
 # (c) 2017
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+import platform
+
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+
 import ecu
 import options
 import elm
@@ -15,19 +38,19 @@ category = _("Airbag Tools")
 need_hw = True
 ecufile = "MRSZ_X95_L38_L43_L47_20110505T101858"
 
-class Virginizer(gui.QDialog):
+class Virginizer(widgets.QDialog):
     def __init__(self):
         super(Virginizer, self).__init__()
         self.airbag_ecu = ecu.Ecu_file(ecufile, True)
-        layout = gui.QVBoxLayout()
-        infos = gui.QLabel(_("Megane III<br>"
+        layout = widgets.QVBoxLayout()
+        infos = widgets.QLabel(_("Megane III<br>"
                            "AIRBAG VIRGINIZER<br><font color='red'>THIS PLUGIN WILL UNLOCK AIRBAG CRASH DATA<br>"
                            "GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
         infos.setAlignment(core.Qt.AlignHCenter)
-        check_button = gui.QPushButton(_("Check ACU Virgin"))
-        self.status_check = gui.QLabel(_("Waiting"))
+        check_button = widgets.QPushButton(_("Check ACU Virgin"))
+        self.status_check = widgets.QLabel(_("Waiting"))
         self.status_check.setAlignment(core.Qt.AlignHCenter)
-        self.virginize_button = gui.QPushButton(_("Virginize ACU"))
+        self.virginize_button = widgets.QPushButton(_("Virginize ACU"))
         layout.addWidget(infos)
         layout.addWidget(check_button)
         layout.addWidget(self.status_check)

--- a/megane3_eps_reset.py
+++ b/megane3_eps_reset.py
@@ -2,8 +2,31 @@
 
 # (c) 2017
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+import platform
+
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+
 import ecu
 import options
 import elm
@@ -15,17 +38,17 @@ category = _("EPS Tools")
 need_hw = True
 
 
-class Virginizer(gui.QDialog):
+class Virginizer(widgets.QDialog):
     def __init__(self):
         super(Virginizer, self).__init__()
         self.megane_eps = ecu.Ecu_file("DAE_X95_X38_X10_v1.88_20120228T113904", True)
-        layout = gui.QVBoxLayout()
-        infos = gui.QLabel(_("ZOE/FLENCE/Megane III/Scenic III EPS VIRGINIZER<br><font color='red'>THIS PLUGIN WILL RESET EPS IMMO DATA<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
+        layout = widgets.QVBoxLayout()
+        infos = widgets.QLabel(_("ZOE/FLENCE/Megane III/Scenic III EPS VIRGINIZER<br><font color='red'>THIS PLUGIN WILL RESET EPS IMMO DATA<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
         infos.setAlignment(core.Qt.AlignHCenter)
-        check_button = gui.QPushButton(_("Check EPS Virgin"))
-        self.status_check = gui.QLabel(_("Waiting"))
+        check_button = widgets.QPushButton(_("Check EPS Virgin"))
+        self.status_check = widgets.QLabel(_("Waiting"))
         self.status_check.setAlignment(core.Qt.AlignHCenter)
-        self.virginize_button = gui.QPushButton(_("Virginize EPS"))
+        self.virginize_button = widgets.QPushButton(_("Virginize EPS"))
         layout.addWidget(infos)
         layout.addWidget(check_button)
         layout.addWidget(self.status_check)

--- a/megane3_uch_reset.py
+++ b/megane3_uch_reset.py
@@ -2,9 +2,31 @@
 
 # (c) 2017
 
+import platform
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+
 import ecu
 import options
 import elm
@@ -16,17 +38,17 @@ category = _("UCH Tools")
 need_hw = True
 ecufile = "BCM_X95_SW_2_V_1_2"
 
-class Virginizer(gui.QDialog):
+class Virginizer(widgets.QDialog):
     def __init__(self):
         super(Virginizer, self).__init__()
         self.megane_uch = ecu.Ecu_file(ecufile, True)
-        layout = gui.QVBoxLayout()
-        infos = gui.QLabel(_("MEGANE III UCH VIRGINIZER<br><font color='red'>THIS PLUGIN WILL ERASE YOUR UCH<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
+        layout = widgets.QVBoxLayout()
+        infos = widgets.QLabel(_("MEGANE III UCH VIRGINIZER<br><font color='red'>THIS PLUGIN WILL ERASE YOUR UCH<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
         infos.setAlignment(core.Qt.AlignHCenter)
-        check_button = gui.QPushButton(_("Check UCH Virgin"))
-        self.status_check = gui.QLabel(_("Waiting"))
+        check_button = widgets.QPushButton(_("Check UCH Virgin"))
+        self.status_check = widgets.QLabel(_("Waiting"))
         self.status_check.setAlignment(core.Qt.AlignHCenter)
-        self.virginize_button = gui.QPushButton(_("Virginize UCH"))
+        self.virginize_button = widgets.QPushButton(_("Virginize UCH"))
         layout.addWidget(infos)
         layout.addWidget(check_button)
         layout.addWidget(self.status_check)

--- a/rsat4_reset.py
+++ b/rsat4_reset.py
@@ -2,9 +2,31 @@
 
 # (c) 2017
 
+import platform
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+
 import ecu
 import options
 import elm
@@ -16,19 +38,19 @@ category = _("Airbag Tools")
 need_hw = True
 ecufile = "RSAT4_ACU_eng_v15_20150511T131328"
 
-class Virginizer(gui.QDialog):
+class Virginizer(widgets.QDialog):
     def __init__(self):
         super(Virginizer, self).__init__()
         self.airbag_ecu = ecu.Ecu_file(ecufile, True)
-        layout = gui.QVBoxLayout()
-        infos = gui.QLabel(_("TWINGO III/ZOE/DOKKER/DUSTER ph2/TRAFIC III/CAPTUR/LODGY ph1/2<br>"
+        layout = widgets.QVBoxLayout()
+        infos = widgets.QLabel(_("TWINGO III/ZOE/DOKKER/DUSTER ph2/TRAFIC III/CAPTUR/LODGY ph1/2<br>"
                            "AIRBAG VIRGINIZER<br><font color='red'>THIS PLUGIN WILL UNLOCK AIRBAG CRASH DATA<br>"
                            "GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>"))
         infos.setAlignment(core.Qt.AlignHCenter)
-        check_button = gui.QPushButton(_("Check ACU Virgin"))
-        self.status_check = gui.QLabel(_("Waiting"))
+        check_button = widgets.QPushButton(_("Check ACU Virgin"))
+        self.status_check = widgets.QLabel(_("Waiting"))
         self.status_check.setAlignment(core.Qt.AlignHCenter)
-        self.virginize_button = gui.QPushButton(_("Virginize ACU"))
+        self.virginize_button = widgets.QPushButton(_("Virginize ACU"))
         layout.addWidget(infos)
         layout.addWidget(check_button)
         layout.addWidget(self.status_check)

--- a/vin_crc.py
+++ b/vin_crc.py
@@ -5,9 +5,31 @@
 
 import crcmod
 from binascii import unhexlify
+import platform
 
-import PyQt4.QtGui as gui
-import PyQt4.QtCore as core
+try:
+    import PyQt5.QtGui as gui
+    import PyQt5.QtCore as core
+    import PyQt5.QtWidgets as widgets
+    if platform.system() == 'Darwin':
+        import PyQt5.QtWebEngine as webkit
+        import PyQt5.QtWebEngineWidgets as webkitwidgets
+    else:
+        import PyQt5.QtWebKit as webkit
+        import PyQt5.QtWebKitWidgets as webkitwidgets
+    def utf8(string):
+        return string
+    qt5 = True
+except:
+    import PyQt4.QtGui as gui
+    import PyQt4.QtGui as widgets
+    import PyQt4.QtCore as core
+    import PyQt4.QtWebKit as webkit
+    import PyQt4.QtWebKit as webkitwidgets
+    def utf8(string):
+        return unicode(string.toUtf8(), encoding="UTF-8")
+    qt5 = False
+
 import options
 
 _ = options.translator('ddt4all')
@@ -29,14 +51,14 @@ def calc_crc(vin=None):
     return crcle[2:4] + crcle[0:2]
 
 
-class CrcWidget(gui.QDialog):
+class CrcWidget(widgets.QDialog):
     def __init__(self):
         super(CrcWidget, self).__init__(None)
-        layout = gui.QVBoxLayout()
-        self.input = gui.QLineEdit()
-        self.output = gui.QLineEdit()
+        layout = widgets.QVBoxLayout()
+        self.input = widgets.QLineEdit()
+        self.output = widgets.QLineEdit()
         self.output.setStyleSheet("QLineEdit { color: rgb(255, 0, 0); }")
-        info = gui.QLabel(_("CRC CALCULATOR"))
+        info = widgets.QLabel(_("CRC CALCULATOR"))
         info.setAlignment(core.Qt.AlignHCenter)
         self.output.setAlignment(core.Qt.AlignHCenter)
         layout.addWidget(info)
@@ -47,7 +69,10 @@ class CrcWidget(gui.QDialog):
         self.output.setReadOnly(True)
 
     def recalc(self):
-        vin = str(self.input.text().toAscii()).upper()
+        if qt5:
+            vin = str(self.input.text().encode("ascii", errors='"ignore')).upper()
+        else:
+            vin = str(self.input.text().toAscii()).upper()
         crc = calc_crc(vin)
         self.output.setText('%s' % crc)
 


### PR DESCRIPTION
I noticed the plugins would crash when running in Qt5 mode (without PyQt4 installed) and ported bits from `ddt4all.py`. Maybe I missed something, but seems at least they don't crash and show work in offline mode (tried VIN decoder and Card programming).