### PR TITLE
Add script to reset EVC water pump counters (Zoé)

### DIFF
--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -209,7 +209,7 @@ class Virginizer(gui.QDialog):
     def reset_ecu(self):
         self.start_diag_session()
         self.reset_low_speed_counter()
-        self.reset_medium_speed_counter()
+        self.reset_middlecounter()
         self.reset_high_speed_counter()
         self.reset_timer_DrivWEP()
 

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -85,7 +85,7 @@ class Virginizer(gui.QDialog):
         <ul>
             <li>Insert key CARD</li>
             <li>Put D position</li>
-            <li>Press/Stay START until "Remove card" message</li>
+            <li>Press/Stay START until <b>"Remove card"</b> message</li>
             <li>Put P position</li>
         </ul>
         """

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -87,6 +87,7 @@ class Virginizer(gui.QDialog):
             <li>Put D position</li>
             <li>Press/Stay START until <b>"Remove card"</b> message</li>
             <li>Put P position</li>
+            <li>Keep key card inserted</li>
         </ul>
         """
 
@@ -171,6 +172,15 @@ class Virginizer(gui.QDialog):
         options.main_window.logview.append(value)
         self.table.setItem(2, 1, QTableWidgetItem(value))
 
+    def start_diag_extend_session(self):
+        sds_request = self.evc_ecu.requests[u"StartDiagnosticSession.ExtendedDiagnosticSession"]
+
+        sds_stream = " ".join(sds_request.build_data_stream({}))
+        if options.simulation_mode:
+            print("SdS stream", sds_stream)
+            return
+        options.elm.start_session_can(sds_stream)
+
     def start_diag_session(self):
         sds_request = self.evc_ecu.requests[u"StartDiagnosticSession.Default"]
 
@@ -181,7 +191,7 @@ class Virginizer(gui.QDialog):
         options.elm.start_session_can(sds_stream)
 
     def reset_lowcounter(self):
-        self.start_diag_session()
+        self.start_diag_extend_session()
         self.reset_low_speed_counter()
 
     def reset_middlecounter(self):
@@ -205,43 +215,43 @@ class Virginizer(gui.QDialog):
 
     def reset_timer_DrivWEP(self):
         reset_request = self.evc_ecu.requests[u"DataWrite.($3531) V_Timer_DrivWEP_ON"]
-        request_response = reset_request.send_request()
+        request_response = reset_request.send_request({"($3531) V_Timer_DrivWEP_ON": "0"})
         print(request_response)
         if request_response is not None:
             self.status_check.setText(_("<font color='green'>CLEAR V_Timer_DrivWEP_ON EXECUTED</font>"))
         else:
             self.status_check.setText(_("<font color='red'>CLEAR V_Timer_DrivWEP_ON FAILED</font>"))
-        self.get_timer_DrivWEP_ON()
+        # self.get_timer_DrivWEP_ON()
 
     def reset_low_speed_counter(self):
         reset_request = self.evc_ecu.requests[u"DataWrite.($3349) Time Counter for the driving WEP in Low Speed"]
-        request_response = reset_request.send_request()
+        request_response = reset_request.send_request({"($3349) Time Counter for the driving WEP in Low Speed": 0})
         print(request_response)
         if request_response is not None:
             self.status_check.setText(_("<font color='green'>CLEAR Low EXECUTED</font>"))
         else:
             self.status_check.setText(_("<font color='red'>CLEAR Low FAILED</font>"))
-        self.get_low_speed_counter()
+        # self.get_low_speed_counter()
 
     def reset_middle_speed_counter(self):
         reset_request = self.evc_ecu.requests[u"DataWrite.($334A) Time Counter for the driving WEP in Middle Speed"]
-        request_response = reset_request.send_request()
+        request_response = reset_request.send_request({"($334A) Time Counter for the driving WEP in Middle Speed": 0})
         print(request_response)
         if request_response is not None:
             self.status_check.setText(_("<font color='green'>CLEAR Medium EXECUTED</font>"))
         else:
             self.status_check.setText(_("<font color='red'>CLEAR Medium FAILED</font>"))
-        self.get_medium_speed_counter()
+        # self.get_medium_speed_counter()
 
     def reset_high_speed_counter(self):
         reset_request = self.evc_ecu.requests[u"DataWrite.($334B) Time Counter for the driving WEP in High Speed"]
-        request_response = reset_request.send_request()
+        request_response = reset_request.send_request({"($334B) Time Counter for the driving WEP in High Speed": 0})
         print(request_response)
         if request_response is not None:
             self.status_check.setText(_("<font color='green'>CLEAR HIGH EXECUTED</font>"))
         else:
             self.status_check.setText(_("<font color='red'>CLEAR HIGH FAILED</font>"))
-        self.get_high_speed_counter()
+        # self.get_high_speed_counter()
 
 def plugin_entry():
     v = Virginizer()

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -195,15 +195,15 @@ class Virginizer(gui.QDialog):
         self.reset_low_speed_counter()
 
     def reset_middlecounter(self):
-        self.start_diag_session()
+        self.start_diag_extend_session()
         self.reset_middle_speed_counter()
 
     def reset_highcounter(self):
-        self.start_diag_session()
+        self.start_diag_extend_session()
         self.reset_high_speed_counter()
 
     def reset_DrivWEP(self):
-        self.start_diag_session()
+        self.start_diag_extend_session()
         self.reset_timer_DrivWEP()
 
     def reset_ecu(self):

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -6,7 +6,7 @@
 
 import PyQt5.QtCore as core
 import PyQt5.QtWidgets as gui
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem
+from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem, QLabel
 import ecu
 import options
 
@@ -22,18 +22,19 @@ class Virginizer(gui.QDialog):
         super(Virginizer, self).__init__()
         self.evc_ecu = ecu.Ecu_file(ecufile, True)
         self.setWindowTitle("Water pump counter")
-        self.setGeometry(100, 100, 480, 320)
+        # x, y, width, high
+        self.setGeometry(100, 100, 480, 420)
 
         layout = gui.QVBoxLayout()
 
         # Création du tableau
         self.table = QTableWidget()
-        self.table.setRowCount(4)  # Nombre de lignes
-        self.table.setColumnCount(3)  # Nombre de colonnes
-        self.table.setHorizontalHeaderLabels(["Name", "Values", "Action"])  # Entêtes de colonnes
+        self.table.setRowCount(4)  # Number of lines
+        self.table.setColumnCount(3)
+        self.table.setHorizontalHeaderLabels(["Name", "Values", "Action"])  # columns headers
         self.table.setColumnWidth(0, 200)
 
-        # Ajout des données dans le tableau
+        # Add data to table
         data = [
             ["Low Speed", "", ""],
             ["Middle Speed", "", ""],
@@ -77,6 +78,21 @@ class Virginizer(gui.QDialog):
         layout.addWidget(check_button)
         layout.addWidget(self.status_check)
         layout.addWidget(self.virginize_button)
+
+        # Créer une liste d'instructions
+        instructions_html = """
+        <h1>TIPS</h1>
+        <ul>
+            <li>Insert key CARD</li>
+            <li>Put D position</li>
+            <li>Press/Stay START until "Remove card" message</li>
+            <li>Put P position</li>
+        </ul>
+        """
+
+        label = QLabel(instructions_html)
+        layout.addWidget(label)
+
         self.setLayout(layout)
         self.virginize_button.setEnabled(True)
         self.virginize_button.clicked.connect(self.reset_ecu)

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -23,7 +23,7 @@ class Virginizer(gui.QDialog):
         self.evc_ecu = ecu.Ecu_file(ecufile, True)
         self.setWindowTitle("Water pump counter")
         # x, y, width, high
-        self.setGeometry(100, 100, 480, 420)
+        self.setGeometry(100, 100, 480, 445)
 
         layout = gui.QVBoxLayout()
 

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# (c) 2017
+# (c) 2025
+# Zoé EVC water pump counter reset values (low, medium, high speed + timer)
 
 import PyQt5.QtCore as core
 import PyQt5.QtWidgets as gui
@@ -47,7 +48,8 @@ class Virginizer(gui.QDialog):
         layout.addWidget(self.table)
 
         infos = gui.QLabel("Zoe water pump counters<br>"
-                             "water pump counters RESET")
+                             "<font color='red'>THIS PLUGIN WILL ERASE WATER PUMP COUNTERS<br>GO AWAY IF YOU HAVE NO IDEA OF WHAT IT MEANS</font>")
+
         infos.setAlignment(core.Qt.AlignHCenter)
         check_button = gui.QPushButton("Check values")
         self.status_check = gui.QLabel("Waiting action")

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -72,7 +72,7 @@ class Virginizer(gui.QDialog):
     def get_counters_values(self):
         self.start_diag_session()
         self.get_low_speed_counter()
-        self.get_middle_speed_counter()
+        self.get_medium_speed_counter()
         self.get_high_speed_counter()
         self.get_timer_DrivWEP_ON()
         self.status_check.setText(_("<font color='green'>Values read</font>"))
@@ -103,7 +103,7 @@ class Virginizer(gui.QDialog):
         options.main_window.logview.append(value)
         self.table.setItem(0, 1, QTableWidgetItem(value))
 
-    def get_middle_speed_counter(self):
+    def get_medium_speed_counter(self):
         key_name = "($334A) Time Counter for the driving WEP in Middle Speed"
         middlespeed_check_request = self.evc_ecu.requests[
             u'DataRead.($334A) Time Counter for the driving WEP in Middle Speed']
@@ -144,17 +144,50 @@ class Virginizer(gui.QDialog):
 
     def reset_ecu(self):
         self.start_diag_session()
+        self.reset_low_speed_counter()
+        self.reset_medium_speed_counter()
+        self.reset_high_speed_counter()
+        self.reset_timer_DrivWEP()
 
+    def reset_timer_DrivWEP(self):
         reset_request = self.evc_ecu.requests[u"DataWrite.($3531) V_Timer_DrivWEP_ON"]
         request_response = reset_request.send_request()
         print(request_response)
         if request_response is not None:
-            self.status_check.setText(_("<font color='green'>CLEAR EXECUTED</font>"))
+            self.status_check.setText(_("<font color='green'>CLEAR V_Timer_DrivWEP_ON EXECUTED</font>"))
         else:
-            self.status_check.setText(_("<font color='red'>CLEAR FAILED</font>"))
-
+            self.status_check.setText(_("<font color='red'>CLEAR V_Timer_DrivWEP_ON FAILED</font>"))
         self.get_timer_DrivWEP_ON()
 
+    def reset_low_speed_counter(self):
+        reset_request = self.evc_ecu.requests[u"DataWrite.($3349) Time Counter for the driving WEP in Low Speed"]
+        request_response = reset_request.send_request()
+        print(request_response)
+        if request_response is not None:
+            self.status_check.setText(_("<font color='green'>CLEAR Low EXECUTED</font>"))
+        else:
+            self.status_check.setText(_("<font color='red'>CLEAR Low FAILED</font>"))
+        self.get_low_speed_counter()
+
+    def reset_medium_speed_counter(self):
+        reset_request = self.evc_ecu.requests[u"DataWrite.($334A) Time Counter for the driving WEP in Middle Speed"]
+        request_response = reset_request.send_request()
+        print(request_response)
+        if request_response is not None:
+            self.status_check.setText(_("<font color='green'>CLEAR Medium EXECUTED</font>"))
+        else:
+            self.status_check.setText(_("<font color='red'>CLEAR Medium FAILED</font>"))
+        self.get_medium_speed_counter()
+
+    def reset_high_speed_counter(self):
+        reset_request = self.evc_ecu.requests[u"DataWrite.($334B) Time Counter for the driving WEP in High Speed"]
+        request_response = reset_request.send_request()
+        print(request_response)
+        if request_response is not None:
+            self.status_check.setText(_("<font color='green'>CLEAR HIGH EXECUTED</font>"))
+        else:
+            self.status_check.setText(_("<font color='red'>CLEAR HIGH FAILED</font>"))
+        self.get_high_speed_counter()
 
 def plugin_entry():
     v = Virginizer()

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -87,9 +87,11 @@ class Virginizer(gui.QDialog):
 
         options.main_window.logview.append("reading V_Timer_DrivWEP_ON")
         pumptimer_check_values = pumptimer_check_request.send_request()
-        print(pumptimer_check_values)
-        value = pumptimer_check_values.get(key_name)
-        value = str(value)
+        print(f"Réponse reçue: {pumptimer_check_values}")
+        if pumptimer_check_values:
+            value = pumptimer_check_values.get(key_name)
+        else:
+            value = "Not found"
         self.table.setItem(3, 1, QTableWidgetItem(value))
 
     def get_low_speed_counter(self):

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -24,6 +24,7 @@ class Virginizer(gui.QDialog):
         self.setWindowTitle("Water pump counter")
         # x, y, width, high
         self.setGeometry(100, 100, 480, 445)
+        self.setFixedSize(480, 445)
 
         layout = gui.QVBoxLayout()
 
@@ -80,17 +81,17 @@ class Virginizer(gui.QDialog):
         layout.addWidget(self.virginize_button)
 
         # Créer une liste d'instructions
-        instructions_html = """
-        <h1>TIPS</h1>
+
+        instructions_html = f"""
+        <h1>{_('TIPS')}</h1>
         <ul>
-            <li>Insert key CARD</li>
-            <li>Put D position</li>
-            <li>Press/Stay START until <b>"Remove card"</b> message</li>
-            <li>Put P position</li>
-            <li>Keep key card inserted</li>
+            <li>{_('Insert key CARD')}</li>
+            <li>{_('Put D position')}</li>
+            <li>{_('Press/Stay START until')} <b>"{_('Remove card')}"</b> {_('message')}</li>
+            <li>{_('Put P position')}</li>
+            <li>{_('Keep key card inserted')}</li>
         </ul>
         """
-
         label = QLabel(instructions_html)
         layout.addWidget(label)
 

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2017
+
+import PyQt5.QtCore as core
+import PyQt5.QtWidgets as gui
+from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem
+import ecu
+import options
+
+_ = options.translator('ddt4all')
+
+plugin_name = _("Zoe water pump Reset")
+category = _("EVC Tools")
+need_hw = True
+ecufile = "EVC_3180_RH5_510_V1.1_20210422T184714"
+
+class Virginizer(gui.QDialog):
+    def __init__(self):
+        super(Virginizer, self).__init__()
+        self.evc_ecu = ecu.Ecu_file(ecufile, True)
+        self.setWindowTitle("Water pump counter")
+        self.setGeometry(100, 100, 400, 300)
+
+        layout = gui.QVBoxLayout()
+
+        # Création du tableau
+        self.table = QTableWidget()
+        self.table.setRowCount(4)  # Nombre de lignes
+        self.table.setColumnCount(2)  # Nombre de colonnes
+        self.table.setHorizontalHeaderLabels(["Nom", "Valeur"])  # Entêtes de colonnes
+
+        # Ajout des données dans le tableau
+        data = [
+            ["Low Speed", ""],
+            ["Middle Speed", ""],
+            ["High Speed", ""],
+            ["V_Timer_DrivWEP_ON", ""], #V_Timer_DrivWEP_ON
+        ]
+
+        for row, (nom, valeur) in enumerate(data):
+            self.table.setItem(row, 0, QTableWidgetItem(nom))
+            self.table.setItem(row, 1, QTableWidgetItem(valeur))
+
+        # Ajout du tableau au layout
+        layout.addWidget(self.table)
+
+        infos = gui.QLabel("Zoe water pump counters<br>"
+                             "water pump counters RESET")
+        infos.setAlignment(core.Qt.AlignHCenter)
+        check_button = gui.QPushButton("Check values")
+        self.status_check = gui.QLabel("Waiting action")
+        self.status_check.setAlignment(core.Qt.AlignHCenter)
+        self.virginize_button = gui.QPushButton("Reset counters")
+        layout.addWidget(infos)
+        layout.addWidget(check_button)
+        layout.addWidget(self.status_check)
+        layout.addWidget(self.virginize_button)
+        self.setLayout(layout)
+        self.virginize_button.setEnabled(True)
+        self.virginize_button.clicked.connect(self.reset_ecu)
+        check_button.clicked.connect(self.get_counters_values)
+        self.ecu_connect()
+
+    def ecu_connect(self):
+        connection = self.evc_ecu.connect_to_hardware()
+        if not connection:
+            options.main_window.logview.append(_("Cannot connect to ECU"))
+            self.finished()
+
+    def get_counters_values(self):
+        self.start_diag_session()
+        self.get_low_speed_counter()
+        self.get_middle_speed_counter()
+        self.get_high_speed_counter()
+        self.get_timer_DrivWEP_ON()
+        self.status_check.setText(_("<font color='green'>Values read</font>"))
+
+
+    def get_timer_DrivWEP_ON(self):
+        key_name = "($3531) V_Timer_DrivWEP_ON"
+        pumptimer_check_request = self.evc_ecu.requests[
+            u'DataRead.($3531) V_Timer_DrivWEP_ON']
+
+        options.main_window.logview.append("reading V_Timer_DrivWEP_ON")
+        pumptimer_check_values = pumptimer_check_request.send_request()
+        print(pumptimer_check_values)
+        value = pumptimer_check_values.get(key_name)
+        value = str(value)
+        self.table.setItem(3, 1, QTableWidgetItem(value))
+
+    def get_low_speed_counter(self):
+        key_name = "($3349) Time Counter for the driving WEP in Low Speed"
+        lowspeed_check_request = self.evc_ecu.requests[
+            u'DataRead.($3349) Time Counter for the driving WEP in Low Speed']
+        options.main_window.logview.append("reading Low speed")
+        lowspeed_check_values = lowspeed_check_request.send_request()
+        print(lowspeed_check_values)
+        value = lowspeed_check_values.get(key_name)
+        value = str(value)
+
+        options.main_window.logview.append(value)
+        self.table.setItem(0, 1, QTableWidgetItem(value))
+
+    def get_middle_speed_counter(self):
+        key_name = "($334A) Time Counter for the driving WEP in Middle Speed"
+        middlespeed_check_request = self.evc_ecu.requests[
+            u'DataRead.($334A) Time Counter for the driving WEP in Middle Speed']
+
+        options.main_window.logview.append("reading Middle speed")
+
+        middlespeed_check_values = middlespeed_check_request.send_request()
+        print(middlespeed_check_values)
+        value = middlespeed_check_values.get(key_name)
+        value = str(value)
+
+        options.main_window.logview.append(value)
+        self.table.setItem(1, 1, QTableWidgetItem(value))
+
+    def get_high_speed_counter(self):
+        key_name = "($334B) Time Counter for the driving WEP in High Speed"
+        highspeed_check_request = self.evc_ecu.requests[
+            u'DataRead.($334B) Time Counter for the driving WEP in High Speed']
+
+        options.main_window.logview.append("reading High speed")
+
+        highspeed_check_values = highspeed_check_request.send_request()
+        print(highspeed_check_values)
+        value = highspeed_check_values.get(key_name)
+        value = str(value)
+
+        options.main_window.logview.append(value)
+        self.table.setItem(2, 1, QTableWidgetItem(value))
+
+    def start_diag_session(self):
+        sds_request = self.evc_ecu.requests[u"StartDiagnosticSession.Default"]
+
+        sds_stream = " ".join(sds_request.build_data_stream({}))
+        if options.simulation_mode:
+            print("SdS stream", sds_stream)
+            return
+        options.elm.start_session_can(sds_stream)
+
+    def reset_ecu(self):
+        self.start_diag_session()
+
+        reset_request = self.evc_ecu.requests[u"DataWrite.($3531) V_Timer_DrivWEP_ON"]
+        request_response = reset_request.send_request()
+        print(request_response)
+        if request_response is not None:
+            self.status_check.setText(_("<font color='green'>CLEAR EXECUTED</font>"))
+        else:
+            self.status_check.setText(_("<font color='red'>CLEAR FAILED</font>"))
+
+        self.get_timer_DrivWEP_ON()
+
+
+def plugin_entry():
+    v = Virginizer()
+    v.exec_()

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -2,6 +2,7 @@
 
 # (c) 2025
 # Zoé EVC water pump counter reset values (low, medium, high speed + timer)
+# cf error code: SYST ELEC A CONTROLLER
 
 import PyQt5.QtCore as core
 import PyQt5.QtWidgets as gui
@@ -21,28 +22,45 @@ class Virginizer(gui.QDialog):
         super(Virginizer, self).__init__()
         self.evc_ecu = ecu.Ecu_file(ecufile, True)
         self.setWindowTitle("Water pump counter")
-        self.setGeometry(100, 100, 400, 300)
+        self.setGeometry(100, 100, 480, 320)
 
         layout = gui.QVBoxLayout()
 
         # Création du tableau
         self.table = QTableWidget()
         self.table.setRowCount(4)  # Nombre de lignes
-        self.table.setColumnCount(2)  # Nombre de colonnes
-        self.table.setHorizontalHeaderLabels(["Nom", "Valeur"])  # Entêtes de colonnes
+        self.table.setColumnCount(3)  # Nombre de colonnes
+        self.table.setHorizontalHeaderLabels(["Name", "Values", "Action"])  # Entêtes de colonnes
         self.table.setColumnWidth(0, 200)
 
         # Ajout des données dans le tableau
         data = [
-            ["Low Speed", ""],
-            ["Middle Speed", ""],
-            ["High Speed", ""],
-            ["V_Timer_DrivWEP_ON", ""], #V_Timer_DrivWEP_ON
+            ["Low Speed", "", ""],
+            ["Middle Speed", "", ""],
+            ["High Speed", "", ""],
+            ["V_Timer_DrivWEP_ON", "", ""], #V_Timer_DrivWEP_ON
         ]
 
-        for row, (nom, valeur) in enumerate(data):
+        for row, (nom, valeur, action) in enumerate(data):
             self.table.setItem(row, 0, QTableWidgetItem(nom))
             self.table.setItem(row, 1, QTableWidgetItem(valeur))
+            self.table.setItem(row, 2, QTableWidgetItem(action))
+
+        resetlowBtn = gui.QPushButton("Reset")
+        self.table.setCellWidget(0, 2, resetlowBtn)
+        resetlowBtn.clicked.connect(self.reset_lowcounter)
+
+        resetmiddleBtn = gui.QPushButton("Reset")
+        self.table.setCellWidget(1, 2, resetmiddleBtn)
+        resetmiddleBtn.clicked.connect(self.reset_middlecounter)
+
+        resethighBtn = gui.QPushButton("Reset")
+        self.table.setCellWidget(2, 2, resethighBtn)
+        resethighBtn.clicked.connect(self.reset_highcounter)
+
+        resetdrivewepBtn = gui.QPushButton("Reset")
+        self.table.setCellWidget(3, 2, resetdrivewepBtn)
+        resetdrivewepBtn.clicked.connect(self.reset_DrivWEP)
 
         # Ajout du tableau au layout
         layout.addWidget(self.table)
@@ -146,6 +164,22 @@ class Virginizer(gui.QDialog):
             return
         options.elm.start_session_can(sds_stream)
 
+    def reset_lowcounter(self):
+        self.start_diag_session()
+        self.reset_low_speed_counter()
+
+    def reset_middlecounter(self):
+        self.start_diag_session()
+        self.reset_middle_speed_counter()
+
+    def reset_highcounter(self):
+        self.start_diag_session()
+        self.reset_high_speed_counter()
+
+    def reset_DrivWEP(self):
+        self.start_diag_session()
+        self.reset_timer_DrivWEP()
+
     def reset_ecu(self):
         self.start_diag_session()
         self.reset_low_speed_counter()
@@ -173,7 +207,7 @@ class Virginizer(gui.QDialog):
             self.status_check.setText(_("<font color='red'>CLEAR Low FAILED</font>"))
         self.get_low_speed_counter()
 
-    def reset_medium_speed_counter(self):
+    def reset_middle_speed_counter(self):
         reset_request = self.evc_ecu.requests[u"DataWrite.($334A) Time Counter for the driving WEP in Middle Speed"]
         request_response = reset_request.send_request()
         print(request_response)

--- a/zoe_waterpump_counter_reset.py
+++ b/zoe_waterpump_counter_reset.py
@@ -29,6 +29,7 @@ class Virginizer(gui.QDialog):
         self.table.setRowCount(4)  # Nombre de lignes
         self.table.setColumnCount(2)  # Nombre de colonnes
         self.table.setHorizontalHeaderLabels(["Nom", "Valeur"])  # Entêtes de colonnes
+        self.table.setColumnWidth(0, 200)
 
         # Ajout des données dans le tableau
         data = [


### PR DESCRIPTION
I don't have DTC error anymore to test in real conditions.

Screenshots in Edition mode:
![Capture d’écran du 2025-02-28 22-25-30](https://github.com/user-attachments/assets/375a8613-b6e6-4597-8b07-6803443bbb38)
![Capture d’écran du 2025-02-28 22-29-16](https://github.com/user-attachments/assets/c151d520-04bc-4acc-aa6a-5a8915704882)



It should reset:
($3349) Time Counter for the driving WEP in Low Speed
($334A) Time Counter for the driving WEP in Middle Speed
($334B) Time Counter for the driving WEP in High Speed
and
($3531) V_Timer_DrivWEP_ON